### PR TITLE
Remove the quotes around "string"

### DIFF
--- a/terraform/templates/configs.tf
+++ b/terraform/templates/configs.tf
@@ -6,7 +6,7 @@ variable "app_prefix" {
 
 variable "stage_name" {
   default = "dev"
-  type    = "string"
+  type    = string
 }
 
 variable "lambda_source_zip_path" {


### PR DESCRIPTION
Good morning, 

There is an error when the user tries to run `terraform init` with any Terraform version above  v0.11.  Tested with Terraform v1.4.4.
This is the error returned

```
Error: Invalid quoted type constraints
│ 
│   on configs.tf line 9, in variable "stage_name":
│    9:   type    = "string"
│ 
│ Terraform 0.11 and earlier required type constraints to be given in quotes, but that form is now deprecated and will be removed in a future version of Terraform. Remove the quotes around
│ "string".
```

*Description of changes:*

Removed the quotes around "string" to run `terraform init` without error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Best regards,

Paco - QA engineer from IriusRisk 
